### PR TITLE
Fix iCalendar line break

### DIFF
--- a/icalendar/components/event_test.go
+++ b/icalendar/components/event_test.go
@@ -115,3 +115,33 @@ func (s *EventSuite) TestQualifiers(c *C) {
 	c.Assert(event.IsRecurrence(), Equals, true)
 	c.Assert(event.IsOverride(), Equals, true)
 }
+
+func (s *EventSuite) TestUnmarshalMultipleLines(c *C) {
+	// Event that has an ATTENDEE that spans 3 lines
+	raw := `BEGIN:VEVENT
+DTSTART;TZID=America/Los_Angeles:20150511T140000
+DTEND;TZID=America/Los_Angeles:20150511T150000
+DTSTAMP:20150511T204516Z
+ORGANIZER;CN=Fakebiz Shared:mailto:fakemcfakebiz.com_b3a0grbjdr4dcje2fc4ikm
+ aeq8@group.calendar.google.com
+UID:na9njgloe10sch3h0uootli104@google.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=Fakebiz
+  Shared;X-NUM-GUESTS=0:mailto:fakemcfakebiz.com_b3a0grbjdr4dcje2fc4ikm
+ aeq8@group.calendar.google.com
+CREATED:20150504T173946Z
+DESCRIPTION:
+LAST-MODIFIED:20150511T204516Z
+LOCATION:Outer space
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Brand Presentation
+TRANSP:OPAQUE
+END:VEVENT`
+
+	e := Event{}
+	err := icalendar.Unmarshal(raw, &e)
+	c.Assert(err, IsNil)
+	c.Assert(len(e.Attendees), Equals, 1)
+	c.Assert(e.Attendees[0].Entry.Address, Equals, "fakemcfakebiz.com_b3a0grbjdr4dcje2fc4ikmaeq8@group.calendar.google.com")
+	c.Assert(e.Attendees[0].Entry.Name, Equals, "Fakebiz Shared")
+}

--- a/icalendar/unmarshal.go
+++ b/icalendar/unmarshal.go
@@ -48,7 +48,7 @@ func tokenizeSlice(slice []string, name ...string) (*token, error) {
 		// "a long line can be split between any two characters by inserting a CRLF immediately followed by a single
 		// linear white space character"
 		line := slice[i]
-		if i < size-1 && strings.HasPrefix(slice[i+1], " ") {
+		for ; i < size-1 && strings.HasPrefix(slice[i+1], " "); i++ {
 			next := slice[i+1]
 			line += next[1:len(next)]
 		}

--- a/icalendar/unmarshal.go
+++ b/icalendar/unmarshal.go
@@ -43,7 +43,16 @@ func tokenizeSlice(slice []string, name ...string) (*token, error) {
 
 	for i := 0; i < size; i++ {
 
+		// Handle iCalendar's space-indented line break format
+		// See: https://www.ietf.org/rfc/rfc2445.txt section 4.1
+		// "a long line can be split between any two characters by inserting a CRLF immediately followed by a single
+		// linear white space character"
 		line := slice[i]
+		if i < size-1 && strings.HasPrefix(slice[i+1], " ") {
+			next := slice[i+1]
+			line += next[1:len(next)]
+		}
+
 		prop := properties.UnmarshalProperty(line)
 
 		if prop.Name.Equals("begin") {


### PR DESCRIPTION
The [iCalendar spec](https://www.ietf.org/rfc/rfc2445.txt) says

> a long line can be split between any two characters by inserting a CRLF immediately followed by a single linear white space character

This adds support for splitting lines by indenting with a space.